### PR TITLE
fix: proxy clone error

### DIFF
--- a/src/object-chronicler.spec.ts
+++ b/src/object-chronicler.spec.ts
@@ -190,4 +190,23 @@ describe('createSpy and BasicHistory Integration Tests', () => {
       createSpy({}, undefined as unknown as BasicHistory);
     }).toThrow('history should be an implementation of History');
   });
+
+  it('should properly handle proxies in history', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const obj: any = {
+      address: { city: 'New York', country: 'USA' },
+      getAddress: function () {
+        return this.address;
+      },
+      setAddress: function (address: (typeof obj)['address']) {
+        this.address = address;
+      },
+    };
+
+    const history = new BasicHistory();
+    const spiedObj = createSpy(obj, history);
+
+    spiedObj.setAddress(spiedObj.getAddress());
+    expect(history.getAll().length).toBe(6);
+  });
 });

--- a/src/proxy-target.ts
+++ b/src/proxy-target.ts
@@ -1,0 +1,1 @@
+export const TARGET_SYMBOL = Symbol('Target: to get original object');

--- a/src/utils/custom-structured-clone.ts
+++ b/src/utils/custom-structured-clone.ts
@@ -1,0 +1,12 @@
+import { TARGET_SYMBOL } from '../proxy-target';
+
+export function customStructuredClone<T>(el: T): T {
+  if (el instanceof Function) {
+    return el;
+  }
+  if (Array.isArray(el)) {
+    return el.map(customStructuredClone) as T;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return structuredClone(((el as any)[TARGET_SYMBOL] ?? el) as T);
+}


### PR DESCRIPTION
There was a problem on passing proxy (in the cases - the one recieved from reading props on spied object) as method param  - as proxy can't be handled with `structuredClone` it was failing the tests
<!--- START AUTOGENERATED NOTES --->
# Contents ([#12](https://github.com/vvscode/object-chronicler/pull/12))

### Other
- proxy clone error

<!--- END AUTOGENERATED NOTES --->